### PR TITLE
Add audit log and mobile menu improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,6 +340,11 @@
             </div>
             </div>
 
+            <section class="audit-log">
+              <h2 data-translate="audit_log">Audit Log</h2>
+              <ul id="audit-log-body"></ul>
+            </section>
+
         </div>
         
         <div id="sales-entry" class="tab-content hidden">

--- a/styles.css
+++ b/styles.css
@@ -309,6 +309,43 @@ textarea:focus {
   margin-right: 12px;
 }
 
+/* Audit Log Styles */
+.audit-log {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  background-color: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+  backdrop-filter: blur(10px);
+}
+.audit-log h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+.audit-log ul {
+  max-height: 16rem;
+  overflow-y: auto;
+}
+.audit-log li {
+  font-size: 0.875rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+}
+.dark-mode .audit-log {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--dark-text);
+  backdrop-filter: blur(12px);
+}
+.dark-mode .audit-log li {
+  border-bottom-color: rgba(255,255,255,0.1);
+}
+@media (max-width: 640px) {
+  .audit-log {
+    padding: 1rem;
+  }
+}
+
 /* --------------------------------------------
    Responsive Adjustments for Small Screens
    -------------------------------------------- */

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,5 @@
 // ui.js
+import { listenToAuditLogs } from './auditLog.js';
 let serviceTypeChart, salesTrendChart;
 let currentLanguage = "en"; // Default language, will be updated by main.js
 let translations = {}; // Will be populated by main.js
@@ -54,6 +55,23 @@ export function updateCharts(salesData) {
   salesTrendChart.options.scales.x.ticks.color = textColor;
   salesTrendChart.options.scales.y.ticks.color = textColor;
   salesTrendChart.update();
+}
+
+export function initializeAuditLog() {
+  const list = document.getElementById('audit-log-body');
+  if (!list) return;
+  listenToAuditLogs((logs) => {
+    list.innerHTML = '';
+    logs.forEach((log) => {
+      const li = document.createElement('li');
+      const time = log.timestamp && log.timestamp.toDate ? log.timestamp.toDate() : new Date();
+      const formatted = time.toLocaleString(currentLanguage === 'ar' ? 'ar-EG' : 'en-US');
+      const amount = typeof log.amount === 'number' ? formatCurrency(log.amount) : '';
+      const client = log.client ? ` - ${log.client}` : '';
+      li.textContent = `${formatted} - ${log.action}${client}${amount ? ' (' + amount + ')' : ''}`;
+      list.appendChild(li);
+    });
+  });
 }
 
 function salesRowContent(sale) {


### PR DESCRIPTION
## Summary
- Integrate Firestore-backed audit log with UI section and styling
- Record audit events for sale creation, updates, and payments
- Auto-collapse mobile navigation on selection for better mobile UX

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`
- `node --check ui.js`

------
https://chatgpt.com/codex/tasks/task_b_6896328712508331936b2700060e46f7